### PR TITLE
Git clone over https for access

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Example application showing usage of [Mapbox Vision SDK](https://vision.mapbox.c
 2. `brew install carthage` (0.31.0 or later)
 
 ## Installation
-1. `git clone git@github.com:mapbox/vision-ios-examples.git`
+1. `git clone https://github.com/mapbox/vision-ios-examples.git`
 1. `cd vision-ios-examples`
 1. `carthage bootstrap --platform ios`
 1. `open demo.xcodeproj`


### PR DESCRIPTION
While testing this out, I'm receiving permission denied. ( I think this is due to 2FA and access tokens ) cloning over https always works.  https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended 

![image](https://user-images.githubusercontent.com/559288/47927130-a6799980-de7f-11e8-9b32-f86a76951757.png)
