### PR TITLE
Moved usage of NavigationService to ARContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-- Changed handling of `NavigationService` with its rerouting, etc. events, now it's not in `MapboxVisionAR` module
+
+- Changed handling of `NavigationService` with its rerouting, etc. events, it's moved out of `MapboxVisionAR` module, now it is in `ARContainerViewController`
 
 ## 1.0-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Changed handling of `NavigationService` with its rerouting, etc. events, now it's not in `MapboxVisionAR` module
+
 ## 1.0-21
 
 - Added support for Swift 4.2

--- a/demo/ContainerViewController.swift
+++ b/demo/ContainerViewController.swift
@@ -12,6 +12,9 @@ private let buttonHeight: CGFloat = 36
 final class ContainerViewController: UIViewController {
     
     weak var delegate: ContainerDelegate? {
+        willSet {
+            backButton.removeTarget(delegate, action: #selector(ContainerDelegate.backButtonPressed), for: .touchUpInside)
+        }
         didSet {
             backButton.addTarget(delegate, action: #selector(ContainerDelegate.backButtonPressed), for: .touchUpInside)
         }
@@ -23,7 +26,7 @@ final class ContainerViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         arContainerViewController.navigationDelegate = self
         
         view.addSubview(backButton)
@@ -390,11 +393,11 @@ private extension SafetyState.ObjectType {
 
 extension ContainerViewController: NavigationManagerDelegate {
     
-    func navigationManager(_ navigationManager: NavigationManager, didUpdate route: MapboxVisionAR.Route) {
+    func navigationService(didUpdate route: MapboxVisionAR.Route) {
         delegate?.didNavigationRouteUpdated(route: route)
     }
     
-    func navigationManagerArrivedAtDestination(_ navigationManager: NavigationManager) {
+    func navigationServiceArrivedAtDestination() {
         delegate?.didNavigationRouteUpdated(route: nil)
     }
 }

--- a/demo/ContainerViewController.swift
+++ b/demo/ContainerViewController.swift
@@ -391,13 +391,13 @@ private extension SafetyState.ObjectType {
     }
 }
 
-extension ContainerViewController: NavigationManagerDelegate {
+extension ContainerViewController: NavigationDelegate {
     
-    func navigationService(didUpdate route: MapboxVisionAR.Route) {
+    func navigation(didUpdate route: MapboxVisionAR.Route) {
         delegate?.didNavigationRouteUpdated(route: route)
     }
     
-    func navigationServiceArrivedAtDestination() {
+    func navigationDidArriveAtDestination() {
         delegate?.didNavigationRouteUpdated(route: nil)
     }
 }


### PR DESCRIPTION
Creating and handling NavigationService out of `VisionARViewController`.

Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
mapbox/mapbox-vision-ios#96