### PR TITLE
Add fake support for UK signs to make ready-for-build `demo` app

### DIFF
--- a/demo/Signs.swift
+++ b/demo/Signs.swift
@@ -591,7 +591,7 @@ extension Sign {
             case .warningSecondRoadLeft:
                 return nil
             }
-        case .china, .other:
+        case .UK, .china, .other: // FIXME: This is fake support for UK signs. Reimplement it as soon as models/assets are available (https://github.com/mapbox/vision-ios-examples/issues/74)
             switch type {
             case .unknown:
                 return nil


### PR DESCRIPTION
Checks:

* [ ] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
https://github.com/mapbox/vision-ios-examples/issues/74
https://github.com/mapbox/mapbox-vision/pull/976
https://github.com/mapbox/mapbox-vision-ios/pull/108