### PR TITLE
Fix info alert on ipad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.0-23
 
 - `MapboxVision` v0.6.0
+- Fixed crash on showing info
+- Removed portrait mode for iPad
 
 ## 1.0-22
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -71,8 +71,6 @@
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/demo/MenuViewController.swift
+++ b/demo/MenuViewController.swift
@@ -297,7 +297,13 @@ final class MenuViewController: UIViewController {
 
     @objc
     private func infoTapped() {
-        let alert = UIAlertController(title: L10n.infoTitle, message: nil, preferredStyle: .actionSheet)
+        let alert: UIAlertController
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            alert = UIAlertController(title: L10n.infoTitle, message: nil, preferredStyle: .alert)
+        } else {
+            alert = UIAlertController(title: L10n.infoTitle, message: nil, preferredStyle: .actionSheet)
+        }
 
         alert.addAction(UIAlertAction(title: L10n.generalTermsOfService, style: .default) { _ in
             guard let url = URL(string: GlobalConstants.tosLink) else { return }


### PR DESCRIPTION
We had a crash on ipads with showing `UIAlertController`, more info in [fabric](https://fabric.io/mapbox14/ios/apps/com.mapbox.visionsdk.demo/issues/b2b932f5116bd6dafafdb447ed730925?time=last-thirty-days)

Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
