### PR TITLE
Update vision to v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0-28
+
+- `MapboxVision` v0.10.0
+- Added detection of construction cones
+- General bugfixes
+- Improved quality of detection/segmentation, especially at night
+- Improved segmentation, now it's more focused on road specific elements. New segmentation model recognizes the following classes: Crosswalk, Hood, MarkupDashed, MarkupDouble, MarkupOther, MarkupSolid, Other, Road, RoadEdge, Sidewalk
+
 ## 1.0-27
 
 - `MapboxVision` v0.9.0

--- a/Cartfile
+++ b/Cartfile
@@ -3,5 +3,5 @@ binary "https://building42.github.io/Specs/Carthage/iOS/Fabric.json"
 github "mapbox/mapbox-navigation-ios" ~> 0.37.0
 github "mapbox/MapboxDirections.swift" ~> 0.30.0
 
-# binary "https://api.mapbox.com/downloads/v1/vision/ios/mapbox-vision-native-all.carthage?access_token=<ADD-TOKEN-HERE>" ~> 0.9.0
-# github "mapbox/mapbox-vision-ios" ~> 0.9.0
+# binary "https://api.mapbox.com/downloads/v1/vision/ios/mapbox-vision-native-all.carthage?access_token=<ADD-TOKEN-HERE>" ~> 0.10.0
+# github "mapbox/mapbox-vision-ios" ~> 0.10.0


### PR DESCRIPTION
The pr bumps vision version to 0.10.0. Please especially pay attention to the changelog

Checks:

* [x] Update changelog
* [x] Rebase to `dev` branch (not required)
* [x] Assign reviewers

Linked issues:
