### PR TITLE
Update Cartfile to use vision v0.12.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -3,5 +3,5 @@ binary "https://building42.github.io/Specs/Carthage/iOS/Fabric.json"
 github "mapbox/mapbox-navigation-ios" ~> 0.37.0
 github "mapbox/MapboxDirections.swift" ~> 0.30.0
 
-# binary "https://api.mapbox.com/downloads/v1/vision/ios/mapbox-vision-native-all.carthage?access_token=<ADD-TOKEN-HERE>" ~> 0.11.0
-# github "mapbox/mapbox-vision-ios" ~> 0.11.0
+# binary "https://api.mapbox.com/downloads/v1/vision/ios/mapbox-vision-native-all.carthage?access_token=<ADD-TOKEN-HERE>" ~> 0.12.0
+# github "mapbox/mapbox-vision-ios" ~> 0.12.0


### PR DESCRIPTION
Checks:

* [x] Update changelog
* [ ] Rebase to `dev` branch
* [x] Assign reviewers

Linked issues:
mapbox/mapbox-vision#2314